### PR TITLE
Set default cpu 0  to avoid redundant TaskDefinition registration 

### DIFF
--- a/lib/hako/container.rb
+++ b/lib/hako/container.rb
@@ -102,6 +102,7 @@ module Hako
     # @return [Hash]
     def default_config
       {
+        'cpu' => 0,
         'env' => {},
         'docker_labels' => {},
         'links' => [],


### PR DESCRIPTION
When I ran same yml twice:
### expected:

```
$ hako oneshot --tag=alpine ruby.yml -- ruby -e "p :hoge"
I, [2016-09-25T03:04:08.872097 #50783]  INFO -- : Registered task definition: arn:aws:ecs:ap-northeast-1:1**********7:task-definition/ruby-oneshot:23
....snip....
$ hako oneshot --tag=alpine ruby.yml -- ruby -e "p :hoge"
I, [2016-09-25T03:04:14.479585 #50873]  INFO -- : Task definition isn't changed
....snip....
```

But actually, another TaskDefinition was registered redundantly.
### actual:

```
$ hako oneshot --tag=alpine ruby.yml -- ruby -e "p :hoge"
I, [2016-09-25T03:04:08.872097 #50783]  INFO -- : Registered task definition: arn:aws:ecs:ap-northeast-1:1**********7:task-definition/ruby-oneshot:23
....snip....
$ hako oneshot --tag=alpine ruby.yml -- ruby -e "p :hoge"
I, [2016-09-25T03:04:32.641310 #51142]  INFO -- : Registered task definition: arn:aws:ecs:ap-northeast-1:1**********7:task-definition/ruby-oneshot:24 #<---- registerd twice!!
```
### my ruby.yml was:

``` yaml
scheduler:
  cluster: sandbox-hoshino
  desired_count: 1
  region: ap-northeast-1
  type: ecs
app:
  image: ruby
  memory: 128
```

This occurs when there is no `cpu:` value in .yml file.

To add`cpu: 0` will solve this.
### The cause of this problem

when your yml does not set cpu(or set nil), ECS  fills the value 0.

```
[1] pry(#<Hako::Schedulers::EcsDefinitionComparator>)> actual_container
=> #<struct Aws::ECS::Types::ContainerDefinition
 name="app",
 image="ruby:alpine",
 cpu=0,
```

So I thought default value of cpu should be 0
